### PR TITLE
Add TODO plans for frontend and backend

### DIFF
--- a/backend.todo.md
+++ b/backend.todo.md
@@ -1,0 +1,20 @@
+# Plan TODO - backend
+
+| Status | Action | File | Type | Priority | Complexity | Current State | Target State | Tests to Update |
+|--------|-------|------|------|---------|-----------|--------------|-------------|----------------|
+| TODO | COMPLETE | routes/sync/import.js | Route | CRITICAL | Medium | Tokens hardcoded | Retrieve user tokens from database | tests/integration/sync.test.js |
+| TODO | COMPLETE | routes/sync/import.js | Route | HIGH | Medium | Sync history placeholder | Fetch sync history from DB | tests/integration/sync.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | CRITICAL | Medium | Playlist not saved | Persist generated playlist in DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Playlists array empty | Load user playlists from DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Playlist variable null | Load playlist details from DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Update logic missing | Update playlist fields in DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Delete logic missing | Remove playlist from DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Add tracks TODO | Insert tracks in playlist DB table | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | HIGH | Medium | Remove track TODO | Delete track from playlist in DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | MEDIUM | Medium | Reorder tracks TODO | Update track positions in DB | tests/integration/playlist.test.js |
+| TODO | COMPLETE | routes/playlist/generate.js | Route | MEDIUM | Medium | Import playlist TODO | Import playlist via services & save | tests/integration/playlist.test.js |
+| TODO | COMPLETE | logic/playlistBuilder.js | Logic | HIGH | High | getUserMusicProfile returns empty | Load profile from DB | tests/logic/playlistBuilder.test.js |
+| TODO | COMPLETE | logic/playlistBuilder.js | Logic | HIGH | High | getAvailableTracks returns empty | Retrieve tracks from DB/services | tests/logic/playlistBuilder.test.js |
+| TODO | COMPLETE | services/dataSyncOld.js | Service | MEDIUM | High | Save functions not implemented | Persist service data and results | tests/services/dataSyncOld.test.js |
+| TODO | COMPLETE | services/dataSyncOld.js | Service | MEDIUM | High | incrementalSync not implemented | Implement incremental synchronization | tests/services/dataSyncOld.test.js |
+

--- a/frontend.todo.md
+++ b/frontend.todo.md
@@ -1,0 +1,15 @@
+# Plan TODO - frontend
+
+| Status | Action | File | Type | Priority | Complexity | Current State | Target State | Tests to Update |
+|--------|-------|------|------|----------|-----------|---------------|-------------|----------------|
+| TODO | CREATE | src/app/auth/callback/page.tsx | Page | CRITICAL | Low | Missing | Handle OAuth redirect and token storage | tests/pages/auth.test.js |
+| TODO | COMPLETE | src/app/auth/forgot-password/page.tsx | Page | HIGH | Low | Placeholder API call | Implement password reset request | tests/pages/auth.test.js |
+| TODO | COMPLETE | src/app/settings/page.tsx | Page | HIGH | Low | Preferences update TODO | Persist user preferences via API | tests/pages/settings.test.js |
+| TODO | COMPLETE | src/app/profile/page.tsx | Page | HIGH | Low | Profile update TODO | Save profile changes via API | tests/pages/profile.test.js |
+| TODO | CREATE | tests/pages/auth.test.js | Test | HIGH | Low | Missing | Cover login, register, callback flows | N/A |
+| TODO | CREATE | tests/pages/settings.test.js | Test | MEDIUM | Low | Missing | Ensure preferences update works | N/A |
+| TODO | CREATE | tests/pages/profile.test.js | Test | MEDIUM | Low | Missing | Ensure profile update works | N/A |
+| TODO | CREATE | tests/contexts/AuthContext.test.tsx | Test | HIGH | Medium | Missing | Validate auth context logic | N/A |
+| TODO | CREATE | tests/contexts/PlayerContext.test.tsx | Test | HIGH | Medium | Missing | Validate player context functions | N/A |
+| TODO | CREATE | tests/services/api.test.ts | Test | MEDIUM | Low | Missing | Mock API client calls | N/A |
+


### PR DESCRIPTION
## Summary
- document pending backend tasks in `backend.todo.md`
- document pending frontend tasks in `frontend.todo.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68603e578f7c8322a401a9bf2ad3150a